### PR TITLE
[`github`] Workflow to automatically build and push `etcd` binaries

### DIFF
--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -18,13 +18,12 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set relase version environment variable
-      run: echo RELEASE_VERSION=${GITHUB_REF#*} >> $GITHUB_ENV
+      run: echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
       env:
         GITHUB_REF: ${{ github.ref }}
     - name: Build etcd
-      run: GOOS=linux REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/build-binary ${VERSION}
+      run: GOOS=linux REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/build-binary ${{ env.RELEASE_VERSION }}
       env:
-        VERSION: ${{ env.RELEASE_VERSION }}
         GITHUB_REPOSITORY: ${{ github.repository }}
     - name: Calculate checksums
       id: calculate_checksums

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -92,6 +92,21 @@ jobs:
         release_name: ${{ steps.extract_tags.outputs.tags }}
         draft: false
         prerelease: false
+    - uses: actions/download-artifact@v4
+      with:
+        name: etcd_output_checksums
+        path: _output/checksums
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload checksums
+      id: upload-checksums
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ./_output/checksums/SHA256SUMS
+        asset_name: SHA256SUMS
+        asset_content_type: text/plain
   releaseassetsarm:
     runs-on: ubuntu-latest
     needs: release
@@ -104,11 +119,6 @@ jobs:
       with:
         name: etcd_output_${{ matrix.platform }}
         path: _output/release-tars
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/download-artifact@v4
-      with:
-        name: etcd_output_checksums
-        path: _output/checksums
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set release version environment variable
       run: echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
@@ -127,13 +137,3 @@ jobs:
         asset_path: ./_output/release-tars/etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
         asset_name: etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
         asset_content_type: application/tar+gzip
-    - name: Upload checksums
-      id: upload-checksums
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: ./_output/checksums/SHA256SUMS
-        asset_name: SHA256SUMS
-        asset_content_type: text/plain

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -92,21 +92,6 @@ jobs:
         release_name: ${{ steps.extract_tags.outputs.tags }}
         draft: false
         prerelease: false
-    - uses: actions/download-artifact@v4
-      with:
-        name: etcd_output_checksums
-        path: _output/checksums
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Upload checksums
-      id: upload-checksums
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: ./_output/checksums/SHA256SUMS
-        asset_name: SHA256SUMS
-        asset_content_type: text/plain
   releaseassetsarm:
     runs-on: ubuntu-latest
     needs: release
@@ -137,3 +122,22 @@ jobs:
         asset_path: ./_output/release-tars/etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
         asset_name: etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
         asset_content_type: application/tar+gzip
+  addchecksum:
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: etcd_output_checksums
+        path: _output/checksums
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload checksums
+      id: upload-checksums
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ./_output/checksums/SHA256SUMS
+        asset_name: SHA256SUMS
+        asset_content_type: text/plain

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -42,17 +42,9 @@ jobs:
         SANITIZED_TARGET_PLATFORM: ${{ env.SANITIZED_TARGET_PLATFORM }}
     - uses: actions/upload-artifact@v4
       with:
-        name: etcd_output_checksums_${{ env.SANITIZED_TARGET_PLATFORM }}
-        path: release/SHA256SUMS
-      env:
-        SANITIZED_TARGET_PLATFORM: ${{ env.SANITIZED_TARGET_PLATFORM }}
-    - name: Merge checksums
-      uses: actions/upload-artifact/merge@v4
-      if: always()
-      with:
         name: etcd_output_checksums
-        pattern: etcd_output_checksums_*
-        delete-merged: true
+        path: release/SHA256SUMS
+        overwrite: true
   release:
     permissions:
       contents: write

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -18,9 +18,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set release version environment variable
-      run: |
-        echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
-        echo RELEASE_VERSION_NO_V=${GITHUB_REF#refs/tags/v} >> $GITHUB_ENV
+      run: echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
       env:
         GITHUB_REF: ${{ github.ref }}
     - name: Set target platform environment variable
@@ -28,9 +26,16 @@ jobs:
       env:
         KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
     - name: Build etcd
-      run: DRY_RUN=true REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/release.sh --no-upload --no-docker-push ${{ env.RELEASE_VERSION_NO_V }}
+      run: REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/build-binary ${{ env.RELEASE_VERSION }}
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
+    - name: Calculate checksums
+      id: calculate_checksums
+      shell: bash
+      working-directory: release/
+      env:
+        ETCD_BUILD_PLATFORM: ${{ matrix.platform }}
+      run: ls . | grep -E '\.tar.gz$|\.zip$' | xargs shasum -a 256 > ./SHA256SUMS
     - uses: actions/upload-artifact@v4
       with:
         name: etcd_output_${{ env.SANITIZED_TARGET_PLATFORM }}
@@ -92,7 +97,7 @@ jobs:
     strategy:
       matrix:
         platform: ["linux-arm64","linux-amd64"]
-        extension: ["tar.gz", "tar.gz.sha256sum"]
+        extension: ["tar.gz"]
     steps:
     - uses: actions/download-artifact@v4
       with:
@@ -102,7 +107,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: etcd_output_checksums
-        path: _output/release-tars
+        path: _output/checksums
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set release version environment variable
       run: echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
@@ -121,14 +126,13 @@ jobs:
         asset_path: ./_output/release-tars/etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
         asset_name: etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
         asset_content_type: application/tar+gzip
-    - name: Upload SHA256 checksums
-      id: upload-sha256sums
+    - name: Upload checksums
+      id: upload-checksums
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: ./_output/release-tars/etcd_output_checksums
-        asset_name: etcd_output_checksums
+        asset_path: ./_output/checksums/SHA256SUMS
+        asset_name: SHA256SUMS
         asset_content_type: text/plain
-

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -10,9 +10,6 @@ permissions: write-all
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: ["linux/arm64","linux/amd64"]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -21,10 +18,6 @@ jobs:
       run: echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
       env:
         GITHUB_REF: ${{ github.ref }}
-    - name: Set target platform environment variable
-      run: echo SANITIZED_TARGET_PLATFORM=${KUBE_BUILD_PLATFORM/\//-} >> $GITHUB_ENV
-      env:
-        KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
     - name: Build etcd
       run: REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/build-binary ${{ env.RELEASE_VERSION }}
       env:
@@ -36,15 +29,8 @@ jobs:
       run: ls . | grep -E '\.tar.gz$|\.zip$' | xargs shasum -a 256 > ./SHA256SUMS
     - uses: actions/upload-artifact@v4
       with:
-        name: etcd_output_${{ env.SANITIZED_TARGET_PLATFORM }}
-        path: release/etcd-${{ env.RELEASE_VERSION }}-${{ env.SANITIZED_TARGET_PLATFORM }}*
-      env:
-        SANITIZED_TARGET_PLATFORM: ${{ env.SANITIZED_TARGET_PLATFORM }}
-    - uses: actions/upload-artifact@v4
-      with:
-        name: etcd_output_checksums
-        path: release/SHA256SUMS
-        overwrite: true
+        name: etcd_output
+        path: release/
   release:
     permissions:
       contents: write
@@ -102,7 +88,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: etcd_output_${{ matrix.platform }}
+        name: etcd_output
         path: _output/release-tars
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set release version environment variable

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set relase version environment variable
+    - name: Set release version environment variable
       run: echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
       env:
         GITHUB_REF: ${{ github.ref }}
@@ -97,9 +97,6 @@ jobs:
     needs: release
     strategy:
       matrix:
-        assets: [
-          "etcd",
-        ]
         platform: ["linux-arm64","linux-amd64"]
         extension: ["tar.gz", "tar.gz.sha256sum"]
     steps:
@@ -108,6 +105,10 @@ jobs:
         name: etcd_output_${{ matrix.platform }}
         path: _output/release-tars
         github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set release version environment variable
+      run: echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
+      env:
+        GITHUB_REF: ${{ github.ref }}
     - name: Display structure of downloaded files
       run: ls -R
       working-directory: _output
@@ -118,6 +119,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: ./_output/release-tars/${{ matrix.assets }}-${{ matrix.platform }}.${{ matrix.extension}}
-        asset_name: ${{ matrix.assets }}-${{ matrix.platform }}.${{ matrix.extension }}
+        asset_path: ./_output/release-tars/etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
+        asset_name: etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
         asset_content_type: application/tar+gzip
+

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: etcd_output_${{ env.SANITIZED_TARGET_PLATFORM }}
-        path: _output/release-tars
+        path: release/etcd-${{ env.RELEASE_VERSION }}-${{ env.SANITIZED_TARGET_PLATFORM }}.tar.gz
       env:
         SANITIZED_TARGET_PLATFORM: ${{ env.SANITIZED_TARGET_PLATFORM }}
   release:

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -17,20 +17,18 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.22
-    - name: Set env
-      run: echo SANITIZED_TARGET_PLATFORM=${ETCD_BUILD_PLATFORM/\//-} >> $GITHUB_ENV
+    - name: Set relase version environment variable
+      run: echo RELEASE_VERSION=${GITHUB_REF#*} >> $GITHUB_ENV
       env:
-        ETCD_BUILD_PLATFORM: ${{ matrix.platform }}
+        GITHUB_REF: ${{ github.ref }}
     - name: Build etcd
-      run: make build
+      run: GOOS=linux ./scripts/build-binary ${VERSION}
+      env:
+        VERSION: ${{ env.RELEASE_VERSION }}
     - name: Calculate checksums
       id: calculate_checksums
       shell: bash
-      working-directory: _output/release-tars
+      working-directory: /release
       env:
         ETCD_BUILD_PLATFORM: ${{ matrix.platform }}
       run: |

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -35,6 +35,10 @@ jobs:
       with:
         name: etcd_output_${{ env.SANITIZED_TARGET_PLATFORM }}
         path: release/etcd-${{ env.RELEASE_VERSION }}-${{ env.SANITIZED_TARGET_PLATFORM }}*
+    - uses: actions/upload-artifact@v4
+      with:
+        name: etcd_output_checksums
+        path: release/SHA256SUMS
   release:
     permissions:
       contents: write
@@ -95,6 +99,11 @@ jobs:
         name: etcd_output_${{ matrix.platform }}
         path: _output/release-tars
         github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/download-artifact@v4
+      with:
+        name: etcd_output_checksums
+        path: _output/release-tars
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set release version environment variable
       run: echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
       env:
@@ -112,7 +121,7 @@ jobs:
         asset_path: ./_output/release-tars/etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
         asset_name: etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
         asset_content_type: application/tar+gzip
-    - name: Upload SHA256Sums
+    - name: Upload SHA256 checksums
       id: upload-sha256sums
       uses: actions/upload-release-asset@v1
       env:

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -28,7 +28,7 @@ jobs:
       env:
         KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
     - name: Build etcd
-      run: REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/release.sh --no-upload --no-docker-push ${{ env.RELEASE_VERSION_NO_V }} --in-place
+      run: DRY_RUN=true REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/release.sh --no-upload --no-docker-push ${{ env.RELEASE_VERSION_NO_V }}
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -28,7 +28,7 @@ jobs:
       env:
         KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
     - name: Build etcd
-      run: REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/release.sh --no-upload --no-docker-push ${{ env.RELEASE_VERSION_NO_V }}
+      run: REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/release.sh --no-upload --no-docker-push ${{ env.RELEASE_VERSION_NO_V }} --in-place
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -22,13 +22,13 @@ jobs:
       env:
         GITHUB_REF: ${{ github.ref }}
     - name: Build etcd
-      run: GOOS=linux REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/build-binary ${{ env.RELEASE_VERSION }}
+      run: REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/build-binary ${{ env.RELEASE_VERSION }}
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
     - name: Calculate checksums
       id: calculate_checksums
       shell: bash
-      working-directory: /release
+      working-directory: release/
       env:
         ETCD_BUILD_PLATFORM: ${{ matrix.platform }}
       run: |

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -21,6 +21,10 @@ jobs:
       run: echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
       env:
         GITHUB_REF: ${{ github.ref }}
+    - name: Set target platform environment variable
+      run: echo SANITIZED_TARGET_PLATFORM=${KUBE_BUILD_PLATFORM/\//-} >> $GITHUB_ENV
+      env:
+        KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
     - name: Build etcd
       run: REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/build-binary ${{ env.RELEASE_VERSION }}
       env:
@@ -41,8 +45,6 @@ jobs:
       with:
         name: etcd_output_${{ env.SANITIZED_TARGET_PLATFORM }}
         path: release/etcd-${{ env.RELEASE_VERSION }}-${{ env.SANITIZED_TARGET_PLATFORM }}.tar.gz
-      env:
-        SANITIZED_TARGET_PLATFORM: ${{ env.SANITIZED_TARGET_PLATFORM }}
   release:
     permissions:
       contents: write

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -18,7 +18,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set release version environment variable
-      run: echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
+      run: |
+        echo RELEASE_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
+        echo RELEASE_VERSION_NO_V=${GITHUB_REF#refs/tags/v} >> $GITHUB_ENV
       env:
         GITHUB_REF: ${{ github.ref }}
     - name: Set target platform environment variable
@@ -26,21 +28,9 @@ jobs:
       env:
         KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
     - name: Build etcd
-      run: REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/build-binary ${{ env.RELEASE_VERSION }}
+      run: REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/release --no-upload --no-docker-push --in-place ${{ env.RELEASE_VERSION_NO_V }}
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
-    - name: Calculate checksums
-      id: calculate_checksums
-      shell: bash
-      working-directory: release/
-      env:
-        ETCD_BUILD_PLATFORM: ${{ matrix.platform }}
-      run: |
-        TARGET_PLATFORM="${ETCD_BUILD_PLATFORM/\//-}"
-        for TARGET_FILE in *"${TARGET_PLATFORM}".tar.gz
-        do
-          sha256sum "$TARGET_FILE" > "${TARGET_FILE}.sha256sum"
-        done
     - uses: actions/upload-artifact@v4
       with:
         name: etcd_output_${{ env.SANITIZED_TARGET_PLATFORM }}
@@ -122,4 +112,14 @@ jobs:
         asset_path: ./_output/release-tars/etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
         asset_name: etcd-${{ env.RELEASE_VERSION }}-${{ matrix.platform }}.${{ matrix.extension }}
         asset_content_type: application/tar+gzip
+    - name: Upload SHA256Sums
+      id: upload-sha256sums
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ./_output/release-tars/etcd_output_checksums
+        asset_name: etcd_output_checksums
+        asset_content_type: text/plain
 

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -33,17 +33,26 @@ jobs:
       id: calculate_checksums
       shell: bash
       working-directory: release/
-      env:
-        ETCD_BUILD_PLATFORM: ${{ matrix.platform }}
       run: ls . | grep -E '\.tar.gz$|\.zip$' | xargs shasum -a 256 > ./SHA256SUMS
     - uses: actions/upload-artifact@v4
       with:
         name: etcd_output_${{ env.SANITIZED_TARGET_PLATFORM }}
         path: release/etcd-${{ env.RELEASE_VERSION }}-${{ env.SANITIZED_TARGET_PLATFORM }}*
+      env:
+        SANITIZED_TARGET_PLATFORM: ${{ env.SANITIZED_TARGET_PLATFORM }}
     - uses: actions/upload-artifact@v4
       with:
-        name: etcd_output_checksums
+        name: etcd_output_checksums_${{ env.SANITIZED_TARGET_PLATFORM }}
         path: release/SHA256SUMS
+      env:
+        SANITIZED_TARGET_PLATFORM: ${{ env.SANITIZED_TARGET_PLATFORM }}
+    - name: Merge checksums
+      uses: actions/upload-artifact/merge@v4
+      if: always()
+      with:
+        name: etcd_output_checksums
+        pattern: etcd_output_checksums_*
+        delete-merged: true
   release:
     permissions:
       contents: write

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -114,7 +114,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: etcd_output_checksums
+        name: etcd_output
         path: _output/checksums
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload checksums

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -22,9 +22,10 @@ jobs:
       env:
         GITHUB_REF: ${{ github.ref }}
     - name: Build etcd
-      run: GOOS=linux ./scripts/build-binary ${VERSION}
+      run: GOOS=linux REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/build-binary ${VERSION}
       env:
         VERSION: ${{ env.RELEASE_VERSION }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
     - name: Calculate checksums
       id: calculate_checksums
       shell: bash

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: etcd_output_${{ env.SANITIZED_TARGET_PLATFORM }}
-        path: release/etcd-${{ env.RELEASE_VERSION }}-${{ env.SANITIZED_TARGET_PLATFORM }}.tar.gz
+        path: release/etcd-${{ env.RELEASE_VERSION }}-${{ env.SANITIZED_TARGET_PLATFORM }}*
   release:
     permissions:
       contents: write

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -1,0 +1,123 @@
+name: Build and Push etcd releases
+
+on:
+  push:
+    # Sequence of patterns matched against refs/heads
+    tags:
+    # Push events on datadog tags
+    - "*-dd*"
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: ["linux/arm64","linux/amd64"]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.22
+    - name: Set env
+      run: echo SANITIZED_TARGET_PLATFORM=${ETCD_BUILD_PLATFORM/\//-} >> $GITHUB_ENV
+      env:
+        ETCD_BUILD_PLATFORM: ${{ matrix.platform }}
+    - name: Build etcd
+      run: make build
+    - name: Calculate checksums
+      id: calculate_checksums
+      shell: bash
+      working-directory: _output/release-tars
+      env:
+        ETCD_BUILD_PLATFORM: ${{ matrix.platform }}
+      run: |
+        TARGET_PLATFORM="${ETCD_BUILD_PLATFORM/\//-}"
+        for TARGET_FILE in *"${TARGET_PLATFORM}".tar.gz
+        do
+          sha256sum "$TARGET_FILE" > "${TARGET_FILE}.sha256sum"
+        done
+    - uses: actions/upload-artifact@v4
+      with:
+        name: etcd_output_${{ env.SANITIZED_TARGET_PLATFORM }}
+        path: _output/release-tars
+      env:
+        SANITIZED_TARGET_PLATFORM: ${{ env.SANITIZED_TARGET_PLATFORM }}
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      upload_url: ${{ steps.create_release_branch.outputs.upload_url }}${{ steps.create_release_tags.outputs.upload_url }}
+    steps:
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+      env:
+        GITHUB_REF: ${{ github.ref }}
+      if: startsWith(github.ref, 'refs/heads/')
+    - name: Create Release for Branch
+      id: create_release_branch
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/heads/')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: branch@${{ steps.extract_branch.outputs.branch  }}
+        tag_name: branch@${{ steps.extract_branch.outputs.branch  }}
+        draft: false
+        prerelease: false
+    - name: Extract tags name
+      shell: bash
+      run: echo "##[set-output name=tags;]$(echo ${GITHUB_REF#refs/tags/})"
+      id: extract_tags
+      env:
+        GITHUB_REF: ${{ github.ref }}
+      if: startsWith(github.ref, 'refs/tags/')
+    - name: Create Release for Tags
+      id: create_release_tags
+      uses: softprops/action-gh-release@v2
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: ${{ steps.extract_tags.outputs.tags }}
+        tag_name: ${{ steps.extract_tags.outputs.tags }}
+        release_name: ${{ steps.extract_tags.outputs.tags }}
+        draft: false
+        prerelease: false
+  releaseassetsarm:
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      matrix:
+        assets: [
+          "etcd",
+        ]
+        platform: ["linux-arm64","linux-amd64"]
+        extension: ["tar.gz", "tar.gz.sha256sum"]
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: etcd_output_${{ matrix.platform }}
+        path: _output/release-tars
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Display structure of downloaded files
+      run: ls -R
+      working-directory: _output
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ./_output/release-tars/${{ matrix.assets }}-${{ matrix.platform }}.${{ matrix.extension}}
+        asset_name: ${{ matrix.assets }}-${{ matrix.platform }}.${{ matrix.extension }}
+        asset_content_type: application/tar+gzip

--- a/.github/workflows/dd-build.yaml
+++ b/.github/workflows/dd-build.yaml
@@ -28,7 +28,7 @@ jobs:
       env:
         KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
     - name: Build etcd
-      run: REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/release --no-upload --no-docker-push --in-place ${{ env.RELEASE_VERSION_NO_V }}
+      run: REPOSITORY=https://github.com/${{ env.GITHUB_REPOSITORY}}.git ./scripts/release.sh --no-upload --no-docker-push ${{ env.RELEASE_VERSION_NO_V }}
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Automates building and pushing `etcd` binaries whenever we create a new branch.