### PR TITLE
Revert remove all github actions test workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,38 @@
+name: E2E
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+        - linux-amd64-e2e
+        - linux-386-e2e
+    steps:
+    - uses: actions/checkout@v2
+    - id: goversion
+      run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ steps.goversion.outputs.goversion }}
+    - run: date
+    - env:
+        TARGET: ${{ matrix.target }}
+      run: |
+        set -euo pipefail
+
+        echo "${TARGET}"
+        case "${TARGET}" in
+          linux-amd64-e2e)
+            make install-gofail
+            CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' FAILPOINTS='true' make test-e2e-release
+            ;;
+          linux-386-e2e)
+            GOARCH=386 CPU='4' EXPECT_DEBUG='true' COVER='false' RACE='true' make test-e2e
+            ;;
+          *)
+            echo "Failed to find target"
+            exit 1
+            ;;
+        esac

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -1,0 +1,33 @@
+name: functional-tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+        - linux-amd64-functional
+    steps:
+    - uses: actions/checkout@v2
+    - id: goversion
+      run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ steps.goversion.outputs.goversion }}
+    - run: date
+    - env:
+        TARGET: ${{ matrix.target }}
+      run: |
+        set -euo pipefail
+
+        echo "${TARGET}"
+        case "${TARGET}" in
+          linux-amd64-functional)
+            GO_BUILD_FLAGS='-v -mod=readonly' ./build && GOARCH=amd64 PASSES='functional' ./test
+            ;;
+          *)
+            echo "Failed to find target"
+            exit 1
+            ;;
+        esac

--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -1,0 +1,21 @@
+---
+name: Go Vulnerability Checker
+on: [push, pull_request]
+permissions: read-all
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - id: goversion
+        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ steps.goversion.outputs.goversion }}
+      - run: date
+      - run: |
+          set -euo pipefail
+
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+
+          find . -name go.mod | xargs -I'{}' /bin/bash -c 'echo scanning $(dirname {}); govulncheck -C $(dirname {}) -show verbose ./...'

--- a/.github/workflows/grpcproxy.yaml
+++ b/.github/workflows/grpcproxy.yaml
@@ -1,0 +1,33 @@
+name: grpcProxy-tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+        - linux-amd64-grpcproxy
+    steps:
+    - uses: actions/checkout@v2
+    - id: goversion
+      run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ steps.goversion.outputs.goversion }}
+    - run: date
+    - env:
+        TARGET: ${{ matrix.target }}
+      run: |
+        set -euo pipefail
+
+        echo "${TARGET}"
+        case "${TARGET}" in
+          linux-amd64-grpcproxy)
+            PASSES='build grpcproxy'  CPU='4' COVER='false' RACE='true' ./test.sh
+            ;;
+          *)
+            echo "Failed to find target"
+            exit 1
+            ;;
+        esac

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,32 @@
+---
+name: Static Analysis
+on: [push, pull_request]
+permissions: read-all
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - id: goversion
+        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ steps.goversion.outputs.goversion }}
+      - run: |
+          set -euo pipefail
+
+          make verify
+      - run: |
+          set -euo pipefail
+
+          make fix
+
+          DIFF=$(git status --porcelain)
+
+          if [ -n "$DIFF" ]; then
+            echo "These files were modified:"
+            echo
+            echo "$DIFF"
+            echo
+            exit 1
+          fi

--- a/.github/workflows/tests-template.yaml
+++ b/.github/workflows/tests-template.yaml
@@ -1,0 +1,76 @@
+---
+name: Reusable Tests Workflow
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runs-on:
+        required: true
+        type: string
+      targets:
+        required: false
+        type: string
+
+jobs:
+  test:
+    runs-on: ${{ inputs.runs-on }}
+    # this is to prevent arm64 jobs from running at forked projects
+    if: inputs.arch == 'amd64' || github.repository == 'etcd-io/etcd'
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(inputs.targets) }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: goversion
+        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ steps.goversion.outputs.goversion }}
+      - run: date
+      - env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+
+          echo "${TARGET}"
+          case "${TARGET}" in
+            linux-test-smoke)
+              GOARCH=${{ inputs.arch }} CPU=4 RACE='false' make test-smoke
+              ;;
+            linux-integration-1-cpu)
+              make install-gofail
+              GOARCH=${{ inputs.arch }} CPU=1 RACE='false' FAILPOINTS='true' make test-integration
+              ;;
+            linux-integration-2-cpu)
+              make install-gofail
+              GOARCH=${{ inputs.arch }} CPU=2 RACE='false' FAILPOINTS='true' make test-integration
+              ;;
+            linux-integration-4-cpu)
+              make install-gofail
+              GOARCH=${{ inputs.arch }} CPU=4 RACE='false' FAILPOINTS='true' make test-integration
+              ;;
+            linux-unit-4-cpu-race)
+              GOARCH=${{ inputs.arch }} RACE='true' CPU='4' GO_TEST_FLAGS='-p=2' make test-unit
+              ;;
+            linux-386-unit-1-cpu)
+              GOOS=linux GOARCH=386 CPU=1 GO_TEST_FLAGS='-p=4' make test-unit
+              ;;
+            all-build)
+              GOARCH=amd64 PASSES='build' ./test.sh
+              GOARCH=386 PASSES='build' ./test.sh
+              GO_BUILD_FLAGS='-v -mod=readonly' GOOS=darwin GOARCH=amd64 ./build.sh
+              GO_BUILD_FLAGS='-v -mod=readonly' GOOS=darwin GOARCH=arm64 ./build.sh
+              GO_BUILD_FLAGS='-v -mod=readonly' GOOS=windows GOARCH=amd64 ./build.sh
+              GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=arm ./build.sh
+              GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=arm64 ./build.sh
+              GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=ppc64le ./build.sh
+              GO_BUILD_FLAGS='-v -mod=readonly' GOARCH=s390x ./build.sh
+              ;;
+            *)
+              echo "Failed to find target"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,15 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  amd64:
+    uses: ./.github/workflows/tests-template.yaml
+    with:
+      arch: amd64
+      runs-on: ubuntu-latest
+      targets: "['linux-test-smoke',
+        'linux-integration-1-cpu',
+        'linux-integration-2-cpu',
+        'linux-integration-4-cpu',
+        'linux-unit-4-cpu-race',
+        'linux-386-unit-1-cpu',
+        'all-build']"

--- a/api/version/version.go
+++ b/api/version/version.go
@@ -26,7 +26,7 @@ import (
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
 	MinClusterVersion = "3.0.0"
-	Version           = "3.5.25-dd.1"
+	Version           = "3.5.25-dd.2"
 	APIVersion        = "unknown"
 
 	// Git SHA Value will be set during build

--- a/client/v2/go.mod
+++ b/client/v2/go.mod
@@ -7,8 +7,8 @@ toolchain go1.24.10
 require (
 	github.com/json-iterator/go v1.1.11
 	github.com/modern-go/reflect2 v1.0.1
-	go.etcd.io/etcd/api/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/api/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.2
 )
 
 require (

--- a/client/v3/go.mod
+++ b/client/v3/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/prometheus/client_golang v1.11.1
-	go.etcd.io/etcd/api/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/api/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.2
 	go.uber.org/zap v1.17.0
 	google.golang.org/grpc v1.71.1
 	sigs.k8s.io/yaml v1.2.0

--- a/etcdctl/go.mod
+++ b/etcdctl/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/urfave/cli v1.22.4
-	go.etcd.io/etcd/api/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/api/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.2
 	go.etcd.io/etcd/client/v2 v2.305.25
-	go.etcd.io/etcd/client/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/etcdutl/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/pkg/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/client/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/etcdutl/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/pkg/v3 v3.5.25-dd.2
 	go.uber.org/zap v1.17.0
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/grpc v1.71.1
@@ -51,8 +51,8 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.3.12 // indirect
-	go.etcd.io/etcd/raft/v3 v3.5.25-dd.1 // indirect
-	go.etcd.io/etcd/server/v3 v3.5.25-dd.1 // indirect
+	go.etcd.io/etcd/raft/v3 v3.5.25-dd.2 // indirect
+	go.etcd.io/etcd/server/v3 v3.5.25-dd.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0 // indirect
 	go.opentelemetry.io/otel v1.34.0 // indirect

--- a/etcdutl/go.mod
+++ b/etcdutl/go.mod
@@ -27,12 +27,12 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.1.3
 	go.etcd.io/bbolt v1.3.12
-	go.etcd.io/etcd/api/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/client/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/pkg/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/raft/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/server/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/api/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/client/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/pkg/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/raft/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/server/v3 v3.5.25-dd.2
 	go.uber.org/zap v1.17.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -22,16 +22,16 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/spf13/cobra v1.1.3
 	go.etcd.io/bbolt v1.3.12
-	go.etcd.io/etcd/api/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/api/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.2
 	go.etcd.io/etcd/client/v2 v2.305.25
-	go.etcd.io/etcd/client/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/etcdctl/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/etcdutl/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/pkg/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/raft/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/server/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/tests/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/client/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/etcdctl/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/etcdutl/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/pkg/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/raft/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/server/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/tests/v3 v3.5.25-dd.2
 	go.uber.org/zap v1.17.0
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/grpc v1.71.1

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0
-	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.2
 	go.uber.org/zap v1.17.0
 	google.golang.org/grpc v1.71.1
 )

--- a/raft/go.mod
+++ b/raft/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cockroachdb/datadriven v1.0.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.4
-	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.2
 )
 
 require (

--- a/server/go.mod
+++ b/server/go.mod
@@ -26,12 +26,12 @@ require (
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
 	go.etcd.io/bbolt v1.3.12
-	go.etcd.io/etcd/api/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/api/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.2
 	go.etcd.io/etcd/client/v2 v2.305.25
-	go.etcd.io/etcd/client/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/pkg/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/raft/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/client/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/pkg/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/raft/v3 v3.5.25-dd.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.20.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -31,14 +31,14 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0
 	go.etcd.io/bbolt v1.3.12
-	go.etcd.io/etcd/api/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/api/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/client/pkg/v3 v3.5.25-dd.2
 	go.etcd.io/etcd/client/v2 v2.305.25
-	go.etcd.io/etcd/client/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/etcdutl/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/pkg/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/raft/v3 v3.5.25-dd.1
-	go.etcd.io/etcd/server/v3 v3.5.25-dd.1
+	go.etcd.io/etcd/client/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/etcdutl/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/pkg/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/raft/v3 v3.5.25-dd.2
+	go.etcd.io/etcd/server/v3 v3.5.25-dd.2
 	go.etcd.io/gofail v0.2.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0
 	go.opentelemetry.io/otel v1.34.0


### PR DESCRIPTION
All tests were removed in https://github.com/etcd-io/etcd/pull/20099, https://github.com/etcd-io/etcd/pull/20236 and
https://github.com/etcd-io/etcd/pull/20315 as part of the upstream migration to prow https://github.com/kubernetes/test-infra/issues/32754.

Since we maintain a fork without tests running in prow, we want to maintain the tests in github actions. Hence this commit reverts the three pull requests mentioned above with the exception of release.yaml since we do not use the docker images built in this repository.
